### PR TITLE
allow subdirs in layer declarations

### DIFF
--- a/example/caros.xml
+++ b/example/caros.xml
@@ -3,12 +3,19 @@
 	<layer_declaration>
 
 		<remote baseurl="git://git.yoctoproject.org/" name="yocto" />
+		<remote baseurl="git://github.com/openembedded/" name="openembedded"/>
 		<remote baseurl="git://github.com/carosio/" name="github"/>
 
 		<baselayer
 			repo="poky"
 			revision="refs/tags/dizzy-12.0.1"
 			remote="yocto" />
+
+		<layer name="meta-openembedded"
+			repo="meta-openembedded"
+			revision="853dcfa0d618dc26bd27b3a1b49494b98d6eee97"
+			subdirs="meta-oe meta-networking meta-python"
+			remote="openembedded" />
 
 		<layer name="meta-caros"
 			repo="meta-caros"

--- a/libredo/ConfCreator.py
+++ b/libredo/ConfCreator.py
@@ -29,7 +29,11 @@ class ConfCreator:
         baselayer = self.declaration.baselayer['repo']
 
         for layername, layer in self.declaration.layers.iteritems():
-            extra_bblayer += " /REDO/source/%s/%s"%(baselayer,layer['name'])
+            if [] != layer['subdirs']:
+                for subdir in layer['subdirs']:
+                    extra_bblayer += " /REDO/source/%s/%s/%s"%(baselayer,layer['name'],subdir)
+            else:
+                extra_bblayer += " /REDO/source/%s/%s"%(baselayer,layer['name'])
 
         self.bblayers = """
 # LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf

--- a/libredo/Declaration.py
+++ b/libredo/Declaration.py
@@ -63,6 +63,11 @@ class Declaration:
                         if not repo_line.attrib.has_key(attribute):
                             raise DeclarationError("attribute [%s] missing in layer declaration"%attribute)
                         layer[attribute] = repo_line.attrib[attribute]
+                    if repo_line.attrib.has_key('subdirs'):
+                        layer['subdirs'] = repo_line.attrib['subdirs'].strip().split()
+                    else:
+                        layer['subdirs'] = []
+
                     new_layers[layer['name']] = layer
                     self.log(6, "added layer [%s]."%layer)
 


### PR DESCRIPTION
some repositories (such as openembedded) got several
subdirectories, each with it's own conf/layer.conf
allow declaring multiple space-separated sub-directories inside the newly
introduced optional attribute 'subdirs' of the <layer> tag

See example in example/caros.xml
