### PR TITLE
allow local.conf fragments from the cmdline

### DIFF
--- a/libredo/ConfCreator.py
+++ b/libredo/ConfCreator.py
@@ -68,4 +68,4 @@ BB_DISKMON_DIRS = "\
     ABORT,${SSTATE_DIR},100M,1K"
 CONF_VERSION = "1"
 %s
-        """%self.declaration.extra_local_conf
+        """%self.declaration.extra_local_conf()

--- a/libredo/Declaration.py
+++ b/libredo/Declaration.py
@@ -14,7 +14,7 @@ class Declaration:
         self.layers = {}
         self.baselayer = None
         self.layer_remotes = {}
-        self.extra_local_conf = ""
+        self._extra_local_conf = [""]
 
         self.loglevel = logging.INFO
         self.logformat = '%(asctime)s %(levelname)s: %(message)s'
@@ -35,6 +35,12 @@ class Declaration:
         elif severity >= 7:
             logging.debug(message)
 
+    def extra_local_conf(self):
+        return "\n".join(self._extra_local_conf + [""])
+
+    def append_local_conf(self, fragment):
+        self._extra_local_conf.append(fragment)
+
     def parse(self, xml_file):
         """
             parse redomat declaration (xml) and add layers and stages to this instance
@@ -46,8 +52,8 @@ class Declaration:
 
         # parse extras for local.conf
         for local_conf in manifest_root.findall("local_conf"):
-            self.extra_local_conf += local_conf.text
-            self.log(6, "added extra_local_conf [%s]."%self.extra_local_conf)
+            self.append_local_conf(local_conf.text)
+            self.log(6, "added extra_local_conf [%s]."%local_conf.text)
 
         # parse layer declaration
         new_layers = {}

--- a/libredo/Redomat.py
+++ b/libredo/Redomat.py
@@ -30,6 +30,7 @@ class Redomat:
         # (allow other user's images as candidates)
         self.include_foreigns = False
 
+        self.command_line_extra_local_conf = []
         # some options, see accessor function for details
         self.build_id = None
         self.match_build_id = None
@@ -59,6 +60,19 @@ class Redomat:
     def set_entry_stage(self, s):
         self._entry_stage = s
 
+    def append_local_conf(self, local_conf_line):
+        """
+        append more lines to the local.conf
+        this is in addition to local.conf-contents
+        declared in the xml files.
+        """
+
+        if self.decl:
+            self.decl.append_local_conf(local_conf_line)
+        else:
+            # this will be added to the decl in set_decl()
+            self.command_line_extra_local_conf.append(local_conf_line)
+
     def log(self, severity, message):
         m = ['[']
         if self.build_id:
@@ -86,6 +100,11 @@ class Redomat:
             set the build declaration to be used for the next build
         """
         self.decl = _decl
+
+        # command-line-extra-local-conf contents might
+        # exist already. (can be added before parsing)
+        while len(self.command_line_extra_local_conf) > 0:
+            self.decl.append_local_conf(self.command_line_extra_local_conf.pop(0))
 
     def set_dryrun(self, dry):
         """

--- a/redomat.py
+++ b/redomat.py
@@ -60,15 +60,18 @@ OPTIONS
     -L, --list-bids
         list all BUILD-IDs
 
+    -a, --append-local-conf
+        append a line to generated local.conf
+
 """
 
 def main(argv):
     # evaluate passed flags
     try:
-        opts, args = getopt.getopt(argv,"hcniFLl:e:t:b:B:U:",
+        opts, args = getopt.getopt(argv,"hcniFLl:e:t:b:B:U:a:",
                 ["help", "checkout", "dry-run", "images", "skip-failure-commit",
                     "list=", "list-bids", "entry=", "target=", "match-build-id",
-                    "new-build-id=", "upgrade="])
+                    "new-build-id=", "upgrade=", "append-local-conf="])
     except getopt.GetoptError, e:
         print(e)
         print(usage())
@@ -117,6 +120,8 @@ def main(argv):
             # print all build IDs
             redo.list_all_buildID()
             sys.exit(0)
+        elif opt in ['-a', '--append-local-conf']:
+            redo.append_local_conf(arg)
 
     # parse declaration(s)
     decl = Declaration()


### PR DESCRIPTION
this change adds the ability to specify local-conf lines on the command line.
the lines are appended to the combined local.conf from all declarations.
