### PR TITLE
add option to tag successful builds

### DIFF
--- a/redomat.py
+++ b/redomat.py
@@ -63,6 +63,9 @@ OPTIONS
     -a, --append-local-conf
         append a line to generated local.conf
 
+    --success-tag=TAG
+        Tag a successful build with TAG using <repo>:<tag> notation.
+
 """
 
 def main(argv):
@@ -71,7 +74,7 @@ def main(argv):
         opts, args = getopt.getopt(argv,"hcniFLl:e:t:b:B:U:a:",
                 ["help", "checkout", "dry-run", "images", "skip-failure-commit",
                     "list=", "list-bids", "entry=", "target=", "match-build-id",
-                    "new-build-id=", "upgrade=", "append-local-conf="])
+                    "new-build-id=", "upgrade=", "append-local-conf=", "success-tag="])
     except getopt.GetoptError, e:
         print(e)
         print(usage())
@@ -94,6 +97,8 @@ def main(argv):
             checkout_mode = True
         elif opt in ['-F', '--skip-failure-commit']:
             redo.set_commitfailures(False)
+        elif opt in ['--success-tag']:
+            redo.set_success_tag(arg)
         elif opt in ['-n', '--dry-run']:
             redo.set_dryrun(True)
         elif opt in ['-B', '--new-build-id']:


### PR DESCRIPTION
Add --success-tag option to tag an successful build. This parameter
takes a full repo:tag so the resulting image can be pushed directly
to a registry.
